### PR TITLE
fix: guard against None chip.data when building supported_ships

### DIFF
--- a/app/services/grouping_service.py
+++ b/app/services/grouping_service.py
@@ -78,8 +78,9 @@ class GroupingService:
                             })
                         bundle_dto.supported_cruise = []
                         for chip in supported_chips:
-                            chip.data["country"] = chip.name
-                        bundle_dto.supported_ships = [CountryDTO.model_validate(chip.data) for chip in supported_chips]
+                            if chip.data is not None:
+                                chip.data["country"] = chip.name
+                        bundle_dto.supported_ships = [CountryDTO.model_validate(chip.data) for chip in supported_chips if chip.data is not None]
                     except Exception as e:
                         logger.error(f"Failed to support chips: {e}")
                     if locale != os.getenv("DEFAULT_LOCALE", "en"):

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -304,8 +304,9 @@ class UserBundleService:
                         where={"p_bundle_id": bundle.bundle_code, "p_group_name": "ships"}
                     )
                     for chip in supported_chips:
-                        chip.data["country"] = chip.name
-                    bundle.supported_ships = [CountryDTO.model_validate(chip.data) for chip in supported_chips]
+                        if chip.data is not None:
+                            chip.data["country"] = chip.name
+                    bundle.supported_ships = [CountryDTO.model_validate(chip.data) for chip in supported_chips if chip.data is not None]
                 except Exception as e:
                     logger.error(f"Failed to fetch supported ships for bundle {bundle.bundle_code}: {e}")
 


### PR DESCRIPTION
Prevents 'NoneType object does not support item assignment' when a tag row returned by get_bundle_tags_by_group_name has no JSON data.